### PR TITLE
Add jQAssistant command for simple data refinement to Java JAR Dependencies Blog

### DIFF
--- a/docs/_posts/2021-02-18-java-jar-dependency-analysis.markdown
+++ b/docs/_posts/2021-02-18-java-jar-dependency-analysis.markdown
@@ -8,37 +8,43 @@ author: JohT
 discussions-id: 35
 ---
 
-[jQAssistant][jqassistant] extracts meta data of java applications 
+[jQAssistant][jqassistant] extracts meta data of java applications
 and writes them into [Neo4j][neo4j], a native graph database. This blog shows how these tools can be
 used to analyze java jar dependencies e.g. for version updates.
 
 ### Table of Contents
+
 {:.no_toc}
+
 1. A markdown unordered list which will be replaced with the table of contents.
 {:toc}
 
-## 1. Getting started
+## Getting started
+
 As described [here][jqassistant getting started], all you need to get started with [jQAssistant][jqassistant getting started] is:
-- [Download it][jqassistant getting started] 
+
+- [Download it][jqassistant getting started]
 - Scan for example the lib directory of jQAssistant itself using `bin\jqassistant.cmd scan -f lib` (Windows) or `bin/jqassistant.sh scan -f lib` (Linux)
 - Start the web application to display and query the collected data using `bin\jqassistant.cmd server` (Windows) or `bin/jqassistant.sh server` (Linux)
 - Open [http://localhost:7474](http://localhost:7474)
 - Sign in without user and password
 - Click on the database symbol on the top left corner
 
-## 2. Get familiar with the data
+## Get familiar with the data
 
 [Neo4j][neo4j] is a graph database and uses [Cypher][neo4j cypher manual] as query language.
 For those who are used to SQL, ["Comparing SQL with Cypher"][neo4j sql to cypher] might be a helpful guideline.
 
 To get familiar with the data, use the database symbol on top left corner and select any of the node types to
-get some examples. Node symbols can be extended to show all relationships. Switching to table view shows all fields and their contents. 
+get some examples. Node symbols can be extended to show all relationships. Switching to table view shows all fields and their contents.
 
-## 3. Query the data
+## Query the data
 
 ### Query class dependencies
+
 Getting some dependencies between classes can be obtained with:
-```
+
+```cypher
  MATCH (dependent:Class)-[:DEPENDS_ON]->(source:Class) 
 RETURN source, dependent 
  LIMIT 25
@@ -46,16 +52,17 @@ RETURN source, dependent
 
 #### Explanation
 
-`MATCH` is somewhat comparable to `SELECT` in SQL. 
+`MATCH` is somewhat comparable to `SELECT` in SQL.
 The variables `dependent` and `source` are references to nodes of type `Class`.
 Every class that depends on another class will be returned.
-If there is no relationship between classes, if there is another type of relationship (like "implements") 
+If there is no relationship between classes, if there is another type of relationship (like "implements")
 or if the dependency is in the opposite direction, then the nodes will be filtered out and will not be part of the result. Finally, all matching source and dependent class nodes will be returned, limited to at most 25.
 
-
 ### Query Artifacts
+
 Getting artifacts and types they require can be done using:
-```
+
+```cypher
  MATCH (source:Artifact)-[:REQUIRES]->(required:Type) 
 RETURN source, required 
  LIMIT 25
@@ -63,12 +70,12 @@ RETURN source, required
 
 #### Explanation
 
-Except for the types this query is pretty the same as the one above. 
+Except for the types this query is pretty the same as the one above.
 
 #### Troubleshooting
 
 The next logical step would be `MATCH (source:Artifact)-[:REQUIRES]->(required:Artifact)`.
-But this returns no results. The reason for that becomes clear while reading the [jQAssistant User Manual][jqassistant artifact scanner]: The scanner does only provide "REQUIRES" between an artifact and a type, 
+But this returns no results. The reason for that becomes clear while reading the [jQAssistant User Manual][jqassistant artifact scanner]: The scanner does only provide "REQUIRES" between an artifact and a type,
 not between two artifacts.
 
 While analyzing jar files, each one is treated separately. Therefore, there will be no relationships between them.
@@ -77,16 +84,18 @@ Caused by the way the jars are analyzed, there are multiple "Class" nodes with t
 
 To summarize, the data is not yet ready to use for specific requirements.
 
-## 4. Data Refinement
-Compared to classical relational databases, graph databases like [Neo4j][neo4j] are by nature very flexible 
+## Data Refinement
+
+Compared to classical relational databases, graph databases like [Neo4j][neo4j] are by nature very flexible
 when it comes to relationships between nodes. The `MERGE` clause can be used to create a new
 relationship if it hadn't been there yet. This is done while querying, which makes it possible to refine the
-data within a query and adapt it to the requirements. 
+data within a query and adapt it to the requirements.
 
 ### Create relationships between Artifacts
 
 The following query connects artifacts with required artifacts and classes with the same full qualified name (fqn). It returns a list of artifacts (jars) and their dependencies.
-```
+
+```cypher
  MATCH (sourceArtifact:Artifact)-[:REQUIRES]->(requiredType:Type) 
       ,(dependencyType:Type)<-[:CONTAINS]-(dependencyArtifact:Artifact)
  WHERE dependencyType.fqn = requiredType.fqn
@@ -102,32 +111,32 @@ For every result in the first line all results of the second line will be return
 Without a `WHERE` clause (or other filter options), this would lead to an enormous amount of data.
 This is comparable to joins in SQL.
 
-Since there is no relationship between types with the same full qualified name yet, they are queried 
+Since there is no relationship between types with the same full qualified name yet, they are queried
 using two comma separated `MATCH` clauses. The `WHERE` class ensures that there will be
 only one result in the second line for every result in the first line.
 
-This is where `MERGE` comes into play. `MERGE (requiredType)-[:IS_SAME_AS]-(dependencyType)` 
-creates an undirected relationship between types with the same full qualified name, 
+This is where `MERGE` comes into play. `MERGE (requiredType)-[:IS_SAME_AS]-(dependencyType)`
+creates an undirected relationship between types with the same full qualified name,
 so that later queries can be made without a potential cartesian product directly by querying the relationship.
 
-It is also possible to add another `MERGE` clause to create one more relationship. 
+It is also possible to add another `MERGE` clause to create one more relationship.
 `(sourceArtifact)-[:REQUIRES]->(dependencyArtifact)` adds the expected but missing directional relationship
 between an artifact and those artifacts it requires.
 
-## 4. Query refined data
+## Query refined data
 
 After adding relationships, artifacts that require other artifacts can easily be queried using:
 
-```
+```cypher
  MATCH (source:Artifact)-[:REQUIRES]->(required:Artifact) 
 RETURN source.fileName, required.fileName
 ```
 
-With [variable length relationships][neo4j variable length relationship] it is possible to query 
+With [variable length relationships][neo4j variable length relationship] it is possible to query
 in a recursive manner. Here is an example that returns all artifacts
 that could be affected by a version update of `/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar`:
 
-```
+```cypher
  MATCH (changed:Artifact)<-[:REQUIRES*]-(dependent:Artifact)
  WHERE changed.fileName = "/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar"
 RETURN changed, dependent LIMIT 10
@@ -137,18 +146,18 @@ RETURN changed, dependent LIMIT 10
 
 ![Neo4j Artifact Graph]({{site.baseurl}}/assets/img/Neo4jArtifactGraph.png)
 
-
 ## Summary
 
 Here are all steps in a nutshell:
 
-- Download [jQAssistant][jqassistant getting started] 
+- Download [jQAssistant][jqassistant getting started]
 - Scan a directory (e.g. "lib") with jars: `bin/jqassistant.sh scan -f lib` (Linux)
 - Start the web application: `bin/jqassistant.sh server` (Linux)
 - Open [http://localhost:7474](http://localhost:7474)
 - Sign in without user or password
 - Create relationships between artifacts and types and return a list of dependent jars with the following query:
-```
+
+```cypher
  MATCH (sourceArtifact:Artifact)-[:REQUIRES]->(requiredType:Type) 
       ,(dependencyType:Type)<-[:CONTAINS]-(dependencyArtifact:Artifact)
  WHERE dependencyType.fqn = requiredType.fqn
@@ -156,8 +165,10 @@ Here are all steps in a nutshell:
  MERGE (sourceArtifact)-[:REQUIRES]->(dependencyArtifact)
 RETURN sourceArtifact.fileName, dependencyArtifact.fileName
 ```
+
 - Query the graph of all artifacts that would be affected by a version update of a given artifact:
-```
+
+```cypher
  MATCH (changed:Artifact)<-[:REQUIRES*]-(dependent:Artifact)
  WHERE changed.fileName = "/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar"
 RETURN changed, dependent LIMIT 10
@@ -167,8 +178,8 @@ RETURN changed, dependent LIMIT 10
 
 ---
 
-
 ## References
+
 - [About jQAssistant][jqassistant]
 - [Getting started with jQAssistant][jqassistant getting started]
 - [Artifact Scanner of jQAssistant][jqassistant artifact scanner]

--- a/docs/_posts/2021-02-18-java-jar-dependency-analysis.markdown
+++ b/docs/_posts/2021-02-18-java-jar-dependency-analysis.markdown
@@ -152,11 +152,11 @@ RETURN source.fileName, required.fileName
 
 With [variable length relationships][neo4j variable length relationship] it is possible to query
 in a recursive manner. Here is an example that returns all artifacts
-that could be affected by a version update of `/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar`:
+that could be affected by a version update of e.g. `/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar`:
 
 ```cypher
  MATCH (changed:Artifact)<-[:REQUIRES*]-(dependent:Artifact)
- WHERE changed.fileName = "/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar"
+ WHERE changed.fileName STARTS WITH "/org.neo4j-neo4j-cypher-ir"
 RETURN changed, dependent LIMIT 10
 ```
 
@@ -182,7 +182,7 @@ Here are all steps using the simple data refinement in a nutshell:
 
   ```cypher
    MATCH (changed:Artifact)<-[:DEPENDS_ON*]-(dependent:Artifact)
-   WHERE changed.fileName = "/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar"
+   WHERE changed.fileName STARTS WITH "/org.neo4j-neo4j-cypher-ir"
   RETURN changed, dependent LIMIT 10
   ```
 
@@ -210,7 +210,7 @@ Here are all steps using the manual data refinement in a nutshell:
 
   ```cypher
    MATCH (changed:Artifact)<-[:REQUIRES*]-(dependent:Artifact)
-   WHERE changed.fileName = "/org.neo4j-neo4j-cypher-ir-3.5-3.5.14.jar"
+   WHERE changed.fileName STARTS WITH "/org.neo4j-neo4j-cypher-ir"
   RETURN changed, dependent LIMIT 10
   ```
 


### PR DESCRIPTION
### Updates

- Update blog article [Analyze java dependencies with jQAssistant](https://joht.github.io/johtizen/data/2021/02/21/java-jar-dependency-analysis.html): [Describe jQAssistant analyze concepts command for simple data refinement](https://github.com/JohT/johtizen/pull/41/commits/299f7259292ffd97e8aa8993f08e247d3f246d9d)

### Enhancements

- [Fix markdown linter warnings](https://github.com/JohT/johtizen/pull/41/commits/5d84f190176e5c68c5a28ac7873124d0a4e690c0)
- [Use STARTS WITH to not depend on a version number](https://github.com/JohT/johtizen/pull/41/commits/059512c32b3a62c2d566e5a424a50133ff037f9d)